### PR TITLE
Updated get-file to use GET instead of AUTH

### DIFF
--- a/cl-dropbox.lisp
+++ b/cl-dropbox.lisp
@@ -65,7 +65,7 @@
                      `(("rev" . ,rev))))
         (merged-path (concatenate 'string *files-uri* root (encode-path path))))
     (multiple-value-bind (body status)
-        (cl-oauth:access-protected-resource merged-path *access-token* :request-method :auth :user-parameters parameter :drakma-args `(:parameters ,parameter))
+        (cl-oauth:access-protected-resource merged-path *access-token* :request-method :get :user-parameters parameter :drakma-args `(:parameters ,parameter))
       (handle-response body status nil))))
 
 (defun get-metadata (&key (path nil path-supplied-p) (root "/dropbox") (decode t))


### PR DESCRIPTION
get-file was previously using :auth as the request method, which caused
Drakma to return the following error:

```
Don't know how to handle method :AUTH
```

Changing the request method to :get fixes this and allows file data to
be downloaded.
